### PR TITLE
Issue28

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,10 +10,6 @@ machine:
         SECRET_KEY: CI
 
 test:
-  pre:
-    - ./manage.py makemigrations
-    - ./manage.py migrate
-    - ./manage.py collectstatic --noinput
   override:
     - coverage run --source=dataset manage.py test
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,10 @@ machine:
         SECRET_KEY: CI
 
 test:
+  pre:
+    - ./manage.py makemigrations
+    - ./manage.py migrate
+    - ./manage.py collectstatic --noinput
   override:
     - coverage run --source=dataset manage.py test
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,7 @@
 dependencies:
+  pre:
+    - ./manage.py makemigrations
+    - ./manage.py migrate
   override:
     - pip install -r requirements.txt
     - pip install coveralls

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,4 @@
 dependencies:
-  pre:
-    - ./manage.py makemigrations
-    - ./manage.py migrate
   override:
     - pip install -r requirements.txt
     - pip install coveralls

--- a/open_fmri/apps/dataset/forms.py
+++ b/open_fmri/apps/dataset/forms.py
@@ -223,7 +223,6 @@ class ContactFormSetHelper(FormHelper):
                 Field('name', css_class="form-control"),
                 Field('email', css_class="form-control"),
                 Field('website', css_class="form-control"),
-                Field('DELETE', css_class="form-control"),
                 css_class="fieldset-control form-control"
             )
         )

--- a/open_fmri/apps/dataset/forms.py
+++ b/open_fmri/apps/dataset/forms.py
@@ -13,12 +13,12 @@ from django.utils.crypto import salted_hmac
 from ckeditor.widgets import CKEditorWidget
 
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import ButtonHolder, Column, Field, Fieldset, \
-    Layout, Row, Submit
+from crispy_forms.layout import (ButtonHolder, Column, Field, Fieldset,
+    Layout, Row, Submit)
 
-from dataset.models import Contact, Dataset, FeaturedDataset, Investigator, \
-    Link, PublicationPubMedLink, PublicationDocument, Revision, Task, \
-    UserDataRequest, ReferencePaper
+from dataset.models import (Contact, Dataset, FeaturedDataset, Investigator,
+    Link, PublicationPubMedLink, PublicationDocument, Revision, Task,
+    UserDataRequest, ReferencePaper)
 
 class ContactForm(Form):
     contact = forms.ModelChoiceField(queryset=Contact.objects.all().order_by('name'))
@@ -188,13 +188,14 @@ class TaskForm(ModelForm):
         super(TaskForm, self).__init__(*args, **kwargs)
         self.fields['cogat_id'].choices = self.get_cogat_tasks()
 
-    
+ContactFormSet = inlineformset_factory(Dataset, Contact, form=NewContactForm,
+                                       extra=1, can_delete=True)
 
 InvestigatorFormSet = inlineformset_factory(
     Dataset, Investigator, form=InvestigatorForm, extra=1, can_delete=True)
 
-LinkFormSet = inlineformset_factory(
-    Dataset, Link, form=LinkForm, extra=1, can_delete=True)
+LinkFormSet = inlineformset_factory(Dataset, Link, form=LinkForm, extra=1,
+                                    can_delete=True)
 
 PublicationDocumentFormSet = inlineformset_factory(
     Dataset, PublicationDocument, form=PublicationDocumentForm, extra=1, 
@@ -209,6 +210,21 @@ RevisionFormSet = inlineformset_factory(
 
 TaskFormSet = inlineformset_factory(
     Dataset, Task, form=TaskForm, extra=1, can_delete=True)
+
+class ContactFormSetHelper(FormHelper):
+    def __init__(self, *args, **kwargs):
+        super(ContactFormSetHelper, self).__init__(*args, **kwargs)
+        self.layout = Layout(
+            Fieldset(
+                "Contact",
+                Field('name', class="form-control"),
+                Field('email', class="form-control"),
+                Field('website', class="form-control"),
+                Field('DELETE', css_class='form-control'),
+                css_class="fieldset-control form-control"
+            )
+        )
+        self.form_tag = False
 
 class InvestigatorFormSetHelper(FormHelper):
     def __init__(self, *args, **kwargs):

--- a/open_fmri/apps/dataset/forms.py
+++ b/open_fmri/apps/dataset/forms.py
@@ -5,7 +5,7 @@ from django import forms
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.forms import Form, ModelForm
-from django.forms.models import inlineformset_factory
+from django.forms.models import formset_factory, inlineformset_factory
 from django.forms.widgets import TextInput
 from django.template.loader import render_to_string
 from django.utils.crypto import salted_hmac
@@ -188,8 +188,7 @@ class TaskForm(ModelForm):
         super(TaskForm, self).__init__(*args, **kwargs)
         self.fields['cogat_id'].choices = self.get_cogat_tasks()
 
-ContactFormSet = inlineformset_factory(Dataset, Contact, form=NewContactForm,
-                                       extra=1, can_delete=True)
+ContactFormSet = formset_factory(NewContactForm, extra=1, can_delete=True)
 
 InvestigatorFormSet = inlineformset_factory(
     Dataset, Investigator, form=InvestigatorForm, extra=1, can_delete=True)
@@ -217,14 +216,15 @@ class ContactFormSetHelper(FormHelper):
         self.layout = Layout(
             Fieldset(
                 "Contact",
-                Field('name', class="form-control"),
-                Field('email', class="form-control"),
-                Field('website', class="form-control"),
+                Field('name', css_class="form-control"),
+                Field('email', css_class="form-control"),
+                Field('website', css_class="form-control"),
                 Field('DELETE', css_class='form-control'),
                 css_class="fieldset-control form-control"
             )
         )
         self.form_tag = False
+
 
 class InvestigatorFormSetHelper(FormHelper):
     def __init__(self, *args, **kwargs):

--- a/open_fmri/apps/dataset/forms.py
+++ b/open_fmri/apps/dataset/forms.py
@@ -21,7 +21,10 @@ from dataset.models import (Contact, Dataset, FeaturedDataset, Investigator,
     UserDataRequest, ReferencePaper)
 
 class ContactForm(Form):
-    contact = forms.ModelChoiceField(queryset=Contact.objects.all().order_by('name'))
+    contact = forms.ModelMultipleChoiceField(
+        queryset=Contact.objects.all(),
+        widget=forms.Select
+    )
 
     def __init__(self, *args, **kwargs):
         super(ContactForm, self).__init__(*args, **kwargs)
@@ -215,7 +218,7 @@ class ContactFormSetHelper(FormHelper):
         super(ContactFormSetHelper, self).__init__(*args, **kwargs)
         self.layout = Layout(
             Fieldset(
-                "Contact",
+                "New Contact Information",
                 Field('name', css_class="form-control"),
                 Field('email', css_class="form-control"),
                 Field('website', css_class="form-control"),

--- a/open_fmri/apps/dataset/forms.py
+++ b/open_fmri/apps/dataset/forms.py
@@ -53,7 +53,7 @@ class NewContactForm(ModelForm):
         self.helper = FormHelper()
         self.helper.layout = Layout(
             Fieldset(
-                "Contact Information",
+                "",
                 Field('name', css_class="form-control"),
                 Field('email', css_class="form-control"),
                 Field('website', css_class="form-control"),
@@ -191,8 +191,8 @@ class TaskForm(ModelForm):
         super(TaskForm, self).__init__(*args, **kwargs)
         self.fields['cogat_id'].choices = self.get_cogat_tasks()
 
-ContactFormSet = modelformset_factory(Contact, NewContactForm, extra=1,
-                                      can_delete=True)
+ContactFormSet = modelformset_factory(Contact, form=NewContactForm,
+                                       extra=1, can_delete=True)
 
 InvestigatorFormSet = inlineformset_factory(
     Dataset, Investigator, form=InvestigatorForm, extra=1, can_delete=True)
@@ -219,7 +219,7 @@ class ContactFormSetHelper(FormHelper):
         super(ContactFormSetHelper, self).__init__(*args, **kwargs)
         self.layout = Layout(
             Fieldset(
-                "Contact Information",
+                "",
                 Field('name', css_class="form-control"),
                 Field('email', css_class="form-control"),
                 Field('website', css_class="form-control"),

--- a/open_fmri/apps/dataset/forms.py
+++ b/open_fmri/apps/dataset/forms.py
@@ -192,7 +192,7 @@ class TaskForm(ModelForm):
         self.fields['cogat_id'].choices = self.get_cogat_tasks()
 
 ContactFormSet = modelformset_factory(Contact, form=NewContactForm,
-                                       extra=1, can_delete=True)
+                                      extra=1, can_delete=True) 
 
 InvestigatorFormSet = inlineformset_factory(
     Dataset, Investigator, form=InvestigatorForm, extra=1, can_delete=True)
@@ -223,7 +223,7 @@ class ContactFormSetHelper(FormHelper):
                 Field('name', css_class="form-control"),
                 Field('email', css_class="form-control"),
                 Field('website', css_class="form-control"),
-                Field('DELETE', css_class='form-control'),
+                Field('DELETE', css_class="form-control"),
                 css_class="fieldset-control form-control"
             )
         )

--- a/open_fmri/apps/dataset/forms.py
+++ b/open_fmri/apps/dataset/forms.py
@@ -5,7 +5,7 @@ from django import forms
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.forms import Form, ModelForm
-from django.forms.models import formset_factory, inlineformset_factory
+from django.forms.models import modelformset_factory, inlineformset_factory
 from django.forms.widgets import TextInput
 from django.template.loader import render_to_string
 from django.utils.crypto import salted_hmac
@@ -22,8 +22,7 @@ from dataset.models import (Contact, Dataset, FeaturedDataset, Investigator,
 
 class ContactForm(Form):
     contact = forms.ModelMultipleChoiceField(
-        queryset=Contact.objects.all(),
-        widget=forms.Select
+        queryset=Contact.objects.all()
     )
 
     def __init__(self, *args, **kwargs):
@@ -54,7 +53,7 @@ class NewContactForm(ModelForm):
         self.helper = FormHelper()
         self.helper.layout = Layout(
             Fieldset(
-                "New Contact Information",
+                "Contact Information",
                 Field('name', css_class="form-control"),
                 Field('email', css_class="form-control"),
                 Field('website', css_class="form-control"),
@@ -70,7 +69,7 @@ class DatasetForm(ModelForm):
             'workflow_stage', 'status', 'project_name', 'summary', 
             'sample_size', 'scanner_type', 'accession_number', 
             'acknowledgements', 'license_title', 'license_url', 'curated',
-            'orientation_warning' 
+            'orientation_warning', 'contacts'
         ]
         
         widgets = {
@@ -94,6 +93,7 @@ class DatasetForm(ModelForm):
             Field('license_title', css_class="form-control"),
             Field('license_url', css_class="form-control"),
             Field('orientation_warning', css_class="form-control"),
+            Field('contacts', css_class="form-control"),
         )
         self.helper.form_tag = False
 
@@ -191,7 +191,8 @@ class TaskForm(ModelForm):
         super(TaskForm, self).__init__(*args, **kwargs)
         self.fields['cogat_id'].choices = self.get_cogat_tasks()
 
-ContactFormSet = formset_factory(NewContactForm, extra=1, can_delete=True)
+ContactFormSet = modelformset_factory(Contact, NewContactForm, extra=1,
+                                      can_delete=True)
 
 InvestigatorFormSet = inlineformset_factory(
     Dataset, Investigator, form=InvestigatorForm, extra=1, can_delete=True)
@@ -218,7 +219,7 @@ class ContactFormSetHelper(FormHelper):
         super(ContactFormSetHelper, self).__init__(*args, **kwargs)
         self.layout = Layout(
             Fieldset(
-                "New Contact Information",
+                "Contact Information",
                 Field('name', css_class="form-control"),
                 Field('email', css_class="form-control"),
                 Field('website', css_class="form-control"),

--- a/open_fmri/apps/dataset/forms.py
+++ b/open_fmri/apps/dataset/forms.py
@@ -192,7 +192,7 @@ class TaskForm(ModelForm):
         self.fields['cogat_id'].choices = self.get_cogat_tasks()
 
 ContactFormSet = modelformset_factory(Contact, form=NewContactForm,
-                                      extra=1, can_delete=True) 
+                                      extra=1) 
 
 InvestigatorFormSet = inlineformset_factory(
     Dataset, Investigator, form=InvestigatorForm, extra=1, can_delete=True)

--- a/open_fmri/apps/dataset/models.py
+++ b/open_fmri/apps/dataset/models.py
@@ -113,7 +113,13 @@ class Dataset(models.Model):
                 list_serv_notify(self)
             if settings.TWITTER_NOTIFY:
                 twitter_notify(self)
-            
+
+def migrate_contacts():
+    datasets = Dataset.objects.all()
+    for dataset in datasets:
+        if dataset.contact:
+            dataset.contacts.add(dataset.contact.pk)
+
 def list_serv_notify(dataset):
     subject = "New dataset avaliable on OpenfMRI.org"
     body = render_to_string(

--- a/open_fmri/apps/dataset/models.py
+++ b/open_fmri/apps/dataset/models.py
@@ -45,6 +45,7 @@ class Contact(models.Model):
     email = models.EmailField(blank=True)
     name = models.CharField(max_length=200, blank=True)
     website = models.TextField(validators=[URLValidator()], blank=True)
+    datasets = models.ManyToManyField('Dataset', related_name='m2m_contact')
     
     def __str__(self):
         return self.name

--- a/open_fmri/apps/dataset/models.py
+++ b/open_fmri/apps/dataset/models.py
@@ -45,7 +45,6 @@ class Contact(models.Model):
     email = models.EmailField(blank=True)
     name = models.CharField(max_length=200, blank=True)
     website = models.TextField(validators=[URLValidator()], blank=True)
-    datasets = models.ManyToManyField('Dataset', related_name='m2m_contact')
     
     def __str__(self):
         return self.name
@@ -89,6 +88,8 @@ class Dataset(models.Model):
     aws_link_url = models.TextField(validators=[URLValidator()], blank=True,
                                     null=True)
     contact = models.ForeignKey('Contact', blank=True, null=True)
+    contacts = models.ManyToManyField('Contact', related_name='m2m_contact',
+                                      blank=True)
     orientation_warning = models.NullBooleanField(default=False, null=True)
     
     def __str__(self):

--- a/open_fmri/apps/dataset/test_urls.py
+++ b/open_fmri/apps/dataset/test_urls.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from model_mommy import mommy as ModelFactory
 
 from dataset.models import Dataset, FeaturedDataset, ReferencePaper
-from dataset.views import DatasetCreate, DatasetList, DatasetUpdate, \
+from dataset.views import DatasetCreateUpdate, DatasetList, \
     DatasetDelete, FeaturedDatasetEdit, FeaturedDatasetDelete, \
     ReferencePaperCreate, ReferencePaperUpdate, ReferencePaperList, \
     ReferencePaperDelete
@@ -27,11 +27,11 @@ class DataSetUrlTestCase(TestCase):
 
     def test_dataset_create(self):
         found = resolve('/dataset/new/')
-        self.assertEqual(found.func.__name__, DatasetCreate.as_view().__name__)
+        self.assertEqual(found.func.__name__, DatasetCreateUpdate.as_view().__name__)
 
     def test_dataset_update(self):
         found = resolve('/dataset/edit/' + str(self.dataset.accession_number))
-        self.assertEqual(found.func.__name__, DatasetUpdate.as_view().__name__)
+        self.assertEqual(found.func.__name__, DatasetCreateUpdate.as_view().__name__)
 
     def test_dataset_delete(self):
         found = resolve('/dataset/delete/' + str(self.dataset.accession_number))

--- a/open_fmri/apps/dataset/test_views.py
+++ b/open_fmri/apps/dataset/test_views.py
@@ -7,7 +7,7 @@ from django.test import TestCase, RequestFactory
 from model_mommy import mommy as ModelFactory
 
 from dataset.models import Dataset, FeaturedDataset
-from dataset.views import DatasetCreate
+from dataset.views import DatasetCreateUpdate
 
 class DatasetViewTestCase(TestCase):
     def setUp(self):
@@ -160,7 +160,6 @@ class DatasetViewTestCase(TestCase):
         response = self.client.post(
             reverse('dataset_update', args=[dataset.accession_number]), data)
         self.assertEqual(response.status_code, 200)
-
 
     '''
     Test to see if the detail view is displaying the three values that the 

--- a/open_fmri/apps/dataset/urls.py
+++ b/open_fmri/apps/dataset/urls.py
@@ -4,7 +4,8 @@ from dataset.views import (DatasetCreateUpdate, DatasetDelete,
     DatasetDetail, DatasetList, FeaturedDatasetEdit,
     FeaturedDatasetDelete, UserDatasetCreate, UserDataRequestCreate,
     UserDataset, ReferencePaperCreate, ReferencePaperUpdate,
-    ReferencePaperDelete, ReferencePaperList)
+    ReferencePaperDelete, ReferencePaperList, ContactCreate, ContactUpdate,
+    ContactList, ContactDelete)
 
 from dataset.api_views import DatasetAPIList, DatasetAPIDetail
 
@@ -74,6 +75,26 @@ urlpatterns = patterns('',
         r'^reference/delete/(?P<pk>\d+)$',
         ReferencePaperDelete.as_view(),
         name='reference_paper_delete'
+    ),
+    url(
+        r'^contact/edit/(?P<pk>\d+)$',
+        ContactUpdate.as_view(),
+        name='contact_update'
+    ),
+    url(
+        r'^contact/new/',
+        ContactCreate.as_view(),
+        name='contact_create'
+    ),
+    url(
+        r'^contact/delete/(?P<pk>\d+)$',
+        ContactDelete.as_view(),
+        name='contact_delete'
+    ),
+    url(
+        r'^contact/list/',
+        ContactList.as_view(),
+        name='contact_list'
     ),
     url(
         r'^$',

--- a/open_fmri/apps/dataset/urls.py
+++ b/open_fmri/apps/dataset/urls.py
@@ -1,22 +1,22 @@
 from django.conf.urls import patterns, url
 
-from dataset.views import DatasetCreate, DatasetDelete, DatasetDetail, \
-    DatasetList, DatasetUpdate, FeaturedDatasetEdit, FeaturedDatasetDelete, \
-    UserDatasetCreate, UserDataRequestCreate, UserDataset, \
-    ReferencePaperCreate, ReferencePaperUpdate, ReferencePaperDelete, \
-    ReferencePaperList
+from dataset.views import (DatasetCreateUpdate, DatasetDelete,
+    DatasetDetail, DatasetList, FeaturedDatasetEdit,
+    FeaturedDatasetDelete, UserDatasetCreate, UserDataRequestCreate,
+    UserDataset, ReferencePaperCreate, ReferencePaperUpdate,
+    ReferencePaperDelete, ReferencePaperList)
 
 from dataset.api_views import DatasetAPIList, DatasetAPIDetail
 
 urlpatterns = patterns('',
     url(
         r'^new/$',
-        DatasetCreate.as_view(),
+        DatasetCreateUpdate.as_view(),
         name='dataset_create'
     ),
     url(
         r'^edit/(?P<pk>ds\d+[a-zA-Z]?)$',
-        DatasetUpdate.as_view(),
+        DatasetCreateUpdate.as_view(),
         name='dataset_update'
     ),
     # this url maintains backwards compatability with old site detail view

--- a/open_fmri/apps/dataset/views.py
+++ b/open_fmri/apps/dataset/views.py
@@ -159,6 +159,15 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
         context['task_formset_helper'] = TaskFormSetHelper()
         context['revision_formset'] = RevisionFormSet(instance=self.object)
         context['revision_formset_helper'] = RevisionFormSetHelper()
+        if self.object:
+            context['contact_formset'] = ContactFormSet(
+                queryset=self.object.contacts.all(),
+            )
+        else:
+            context['contact_formset'] = ContactFormSet(
+                queryset=Contact.objects.none(),
+            )
+        context['contact_formset_helper'] = ContactFormSetHelper()
         return context
 
     def form_valid(self, form):
@@ -206,6 +215,13 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
         else:
             invalid_form = True
 
+        contact_formset = ContactFormSet(self.request.POST)
+        if contact_formset.is_valid():
+            contact_forms = contact_formset.save()
+            for contact_form in contact_forms:
+                dataset.contacts.add(contact_form)
+        else:
+            invalid_form = True
         
         if invalid_form:
             context = {
@@ -217,6 +233,8 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
                 'publication_pubmed_link_formset': publication_pubmed_link_formset,
                 'revision_formset': revision_formset,
                 'task_formset': task_formset,
+                'contact_formset': contact_formset,
+                'contact_formset_helper': ContactFormSetHelper(),
                 'investigator_formset_helper': InvestigatorFormSetHelper(),
                 'link_formset_helper': LinkFormSetHelper(),
                 'publication_document_formset_helper': PublicationDocumentFormSetHelper(),

--- a/open_fmri/apps/dataset/views.py
+++ b/open_fmri/apps/dataset/views.py
@@ -14,13 +14,13 @@ from django.views.generic.detail import SingleObjectTemplateResponseMixin
 
 from braces.views import LoginRequiredMixin
 
-from dataset.forms import (ContactForm, DatasetForm, FeaturedDatasetForm,
-    InvestigatorFormSet, InvestigatorFormSetHelper, LinkFormSet,
-    LinkFormSetHelper, PublicationDocumentFormSet,
-    PublicationDocumentFormSetHelper, PublicationPubMedLinkFormSet,
-    PublicationPubMedLinkFormSetHelper, RevisionFormSet,
-    RevisionFormSetHelper, TaskFormSet, TaskFormSetHelper, UserDatasetForm,
-    UserDataRequestForm, NewContactForm, ReferencePaperForm)
+from dataset.forms import (ContactForm, ContactFormSet, ContactFormSetHelper,
+    DatasetForm, FeaturedDatasetForm, InvestigatorFormSet,
+    InvestigatorFormSetHelper, LinkFormSet, LinkFormSetHelper,
+    PublicationDocumentFormSet, PublicationDocumentFormSetHelper,
+    PublicationPubMedLinkFormSet, PublicationPubMedLinkFormSetHelper, 
+    RevisionFormSet, RevisionFormSetHelper, TaskFormSet, TaskFormSetHelper,
+    UserDatasetForm, UserDataRequestForm, NewContactForm, ReferencePaperForm)
 from dataset.models import (Dataset, Investigator, PublicationDocument,
     PublicationPubMedLink, FeaturedDataset, UserDataRequest, ReferencePaper)
 from log_parse.models import S3File
@@ -138,6 +138,8 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
         context['task_formset_helper'] = TaskFormSetHelper()
         context['revision_formset'] = RevisionFormSet(instance=self.object)
         context['revision_formset_helper'] = RevisionFormSetHelper()
+        context['contact_formset'] = ContactFormSet()
+        context['contact_formset_helper'] = ContactFormSetHelper()
         return context
 
     def form_valid(self, form):

--- a/open_fmri/apps/dataset/views.py
+++ b/open_fmri/apps/dataset/views.py
@@ -142,7 +142,7 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
         context['revision_formset_helper'] = RevisionFormSetHelper()
         if self.object:
             context['contact_formset'] = ContactFormSet(
-                queryset=object.contacts.all(),
+                queryset=self.object.contacts.all(),
             )
         else:
             context['contact_formset'] = ContactFormSet(

--- a/open_fmri/apps/dataset/views.py
+++ b/open_fmri/apps/dataset/views.py
@@ -110,7 +110,9 @@ class DatasetDetail(DetailView):
         context['revisions'] = context_revisions
         context['other_links'] = context_links
         context['ref_papers'] = self.object.referencepaper_set.all()
-        context['has_contacts'] = self.object.contacts.all().count() > 0
+        contacts = self.object.contacts.all().order_by('name')
+        context['has_contacts'] = contacts.count() > 0
+        context['contacts'] = contacts
         return context
 
 class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,

--- a/open_fmri/apps/dataset/views.py
+++ b/open_fmri/apps/dataset/views.py
@@ -7,25 +7,25 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.shortcuts import redirect, render, get_object_or_404
 from django.utils.crypto import constant_time_compare, salted_hmac
-from django.views.generic import CreateView, DeleteView, DetailView, \
-    ListView, UpdateView, TemplateView, View 
+from django.views.generic import (CreateView, DeleteView, DetailView,
+    ListView, UpdateView, TemplateView, View)
 from django.views.generic.edit import ModelFormMixin, ProcessFormView 
 from django.views.generic.detail import SingleObjectTemplateResponseMixin
 
 from braces.views import LoginRequiredMixin
 
-from dataset.forms import ContactForm, DatasetForm, FeaturedDatasetForm, \
-    InvestigatorFormSet, InvestigatorFormSetHelper, LinkFormSet, \
-    LinkFormSetHelper, PublicationDocumentFormSet, \
-    PublicationDocumentFormSetHelper, PublicationPubMedLinkFormSet, \
-    PublicationPubMedLinkFormSetHelper, RevisionFormSet, \
-    RevisionFormSetHelper, TaskFormSet, TaskFormSetHelper, UserDatasetForm, \
-    UserDataRequestForm, NewContactForm, ReferencePaperForm
-from dataset.models import Dataset, Investigator, PublicationDocument, \
-    PublicationPubMedLink, FeaturedDataset, UserDataRequest, ReferencePaper
+from dataset.forms import (ContactForm, DatasetForm, FeaturedDatasetForm,
+    InvestigatorFormSet, InvestigatorFormSetHelper, LinkFormSet,
+    LinkFormSetHelper, PublicationDocumentFormSet,
+    PublicationDocumentFormSetHelper, PublicationPubMedLinkFormSet,
+    PublicationPubMedLinkFormSetHelper, RevisionFormSet,
+    RevisionFormSetHelper, TaskFormSet, TaskFormSetHelper, UserDatasetForm,
+    UserDataRequestForm, NewContactForm, ReferencePaperForm)
+from dataset.models import (Dataset, Investigator, PublicationDocument,
+    PublicationPubMedLink, FeaturedDataset, UserDataRequest, ReferencePaper)
 from log_parse.models import S3File
 
-requests_cache.install_cache('test_cache')
+requests_cache.install_cache('cache')
 
 class DatasetList(ListView):
     model = Dataset
@@ -92,27 +92,49 @@ class DatasetDetail(DetailView):
         context['ref_papers'] = self.object.referencepaper_set.all()
         return context
 
-class DatasetCreate(LoginRequiredMixin, CreateView):
+
+class DatasetCreateUpdate(SingleObjectTemplateResponseMixin,
+                              ModelFormMixin, ProcessFormView):
     model = Dataset
     form_class = DatasetForm
     success_url = reverse_lazy('dataset_list')
+    template_name = 'dataset/dataset_form.html'
+
+    def get_object(self, queryset=None):
+        try:
+            return super(DatasetCreateUpdate, self).get_object(queryset)
+        except AttributeError:
+            return None
+
+    def get(self, *args, **kwargs):
+        self.object = self.get_object()
+        return super(DatasetCreateUpdate, self).get(self.request, *args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        self.object = self.get_object()
+        return super(DatasetCreateUpdate, self).post(self.request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
-        context = super(DatasetCreate, self).get_context_data(**kwargs)
-        context['contact_form'] = ContactForm()
+        context = super(DatasetCreateUpdate, self).get_context_data(**kwargs)
+        contact_pk = 0
+        if self.object and self.object.contact:
+            contact_pk = self.object.contact.pk
+        context['contact_form'] = ContactForm(
+            initial = {'contact': contact_pk}
+        )
         context['investigator_formset'] = InvestigatorFormSet()
         context['investigator_formset_helper'] = InvestigatorFormSetHelper()
-        context['link_formset'] = LinkFormSet()
+        context['link_formset'] = LinkFormSet(instance=self.object)
         context['link_formset_helper'] = LinkFormSetHelper()
         context['new_contact_form'] = NewContactForm()
-        context['publication_document_formset'] = PublicationDocumentFormSet()
+        context['publication_document_formset'] = PublicationDocumentFormSet(instance=self.object)
         context['publication_document_formset_helper'] = \
             PublicationDocumentFormSetHelper()
         context['publication_pubmed_link_formset'] = \
-            PublicationPubMedLinkFormSet()
+            PublicationPubMedLinkFormSet(instance=self.object)
         context['publication_pubmed_link_formset_helper'] = \
             PublicationPubMedLinkFormSetHelper()
-        context['task_formset'] = TaskFormSet()
+        context['task_formset'] = TaskFormSet(instance=self.object)
         context['task_formset_helper'] = TaskFormSetHelper()
         context['revision_formset'] = RevisionFormSet(instance=self.object)
         context['revision_formset_helper'] = RevisionFormSetHelper()
@@ -175,101 +197,29 @@ class DatasetCreate(LoginRequiredMixin, CreateView):
             invalid_form = True
         
         if invalid_form:
-            forms = {
+            context = {
+                'request': self.request,
+                'form': form,
                 'new_contact_form': new_contact_form,
                 'contact_form': contact_form,
                 'investigator_formset': investigator_formset,
                 'link_formset': link_formset,
                 'publication_document_formset': publication_document_formset,
-                'publication_pubmed_link': publication_pubmed_link,
+                'publication_pubmed_link_formset': publication_pubmed_link_formset,
                 'revision_formset': revision_formset,
-                'task_formset': task_formset
+                'task_formset': task_formset,
+                'investigator_formset_helper': InvestigatorFormSetHelper(),
+                'link_formset_helper': LinkFormSetHelper(),
+                'publication_document_formset_helper': PublicationDocumentFormSetHelper(),
+                'publication_pubmed_link_formset_helper': PublicationPubMedLinkFormSetHelper(),
+                'task_formset_helper': TaskFormSetHelper(),
+                'revision_formset_helper': RevisionFormSetHelper()
             }
-            return self.render_to_response(self.get_context_data(**forms))
+            return self.render_to_response(context)
         else:
-            return super(DatasetCreate, self).form_valid(form)
+            return super(DatasetCreateUpdate, self).form_valid(form)
 
-class DatasetUpdate(LoginRequiredMixin, UpdateView):
-    model = Dataset
-    form_class = DatasetForm
-    success_url = reverse_lazy('dataset_list')
-    
 
-    def get_context_data(self, **kwargs):
-        context = super(DatasetUpdate, self).get_context_data(**kwargs)
-        contact_pk = 0
-        if self.object.contact:
-            contact_pk = self.object.contact.pk
-        context['contact_form'] = ContactForm(initial = {'contact': contact_pk})
-        context['investigator_formset'] = InvestigatorFormSet(
-            instance=self.object)
-        context['investigator_formset_helper'] = InvestigatorFormSetHelper()
-        context['link_formset'] = LinkFormSet(instance=self.object)
-        context['link_formset_helper'] = LinkFormSetHelper()
-        context['new_contact_form'] = NewContactForm()
-        context['publication_document_formset'] = PublicationDocumentFormSet(
-            instance=self.object)
-        context['publication_document_formset_helper'] = \
-            PublicationDocumentFormSetHelper()
-        context['publication_pubmed_link_formset'] = \
-            PublicationPubMedLinkFormSet(instance=self.object)
-        context['publication_pubmed_link_formset_helper'] = \
-            PublicationPubMedLinkFormSetHelper()
-        context['task_formset'] = TaskFormSet(instance=self.object)
-        context['task_formset_helper'] = TaskFormSetHelper()
-        context['revision_formset'] = RevisionFormSet(instance=self.object)
-        context['revision_formset_helper'] = RevisionFormSetHelper()
-        return context
-
-    def form_valid(self, form):
-        dataset = form.save()
-
-        new_contact_form = NewContactForm(self.request.POST)
-        contact_form = ContactForm(self.request.POST)
-        if new_contact_form.is_valid() and new_contact_form.has_changed():
-            new_contact = new_contact_form.save()
-            new_contact.save()
-            dataset.contact = new_contact
-        elif contact_form.is_valid():
-            dataset.contact = contact_form.cleaned_data['contact']
-        else:
-            pass
-        
-        investigator_formset = InvestigatorFormSet(self.request.POST,
-            self.request.FILES, instance=self.object)
-        if investigator_formset.is_valid():
-            investigator_formset.save()
-
-        link_formset = LinkFormSet(self.request.POST, instance=self.object)
-        if link_formset.is_valid():
-            link_formset.save()
-
-        publication_document_formset = PublicationDocumentFormSet(
-            self.request.POST, self.request.FILES, instance=self.object)
-        if publication_document_formset.is_valid():
-            publication_document_formset.save()
-        
-        publication_pubmed_link_formset = PublicationPubMedLinkFormSet(
-            self.request.POST, instance=self.object)
-        if publication_pubmed_link_formset.is_valid():
-            publication_pubmed_link_formset.save()
-
-        revision_formset = RevisionFormSet(self.request.POST, 
-            instance=self.object)
-        if revision_formset.is_valid():
-            revision_formset.save()
-        
-        task_formset = TaskFormSet(self.request.POST, self.request.FILES,
-            instance=self.object)
-        if task_formset.is_valid():
-            task_formset.save()
-        else:
-            form_empty_permitted = task_formset.forms[-1].empty_permitted
-            form_has_changed = task_formset.forms[-1].changed_data
-            total_forms = task_formset.total_form_count()
-            raise forms.ValidationError(task_formset.errors)
-            
-        return super(DatasetUpdate, self).form_valid(form)
 
 class FeaturedDatasetEdit(LoginRequiredMixin, CreateView):
     model = FeaturedDataset
@@ -300,7 +250,8 @@ class UserDataRequestCreate(LoginRequiredMixin, CreateView):
         user_request.save()
         return super(UserDataRequestCreate, self).form_valid(form)
 
-class UserDataset(SingleObjectTemplateResponseMixin, ModelFormMixin, ProcessFormView):
+class UserDataset(SingleObjectTemplateResponseMixin, ModelFormMixin,
+                  ProcessFormView):
     model = Dataset
     form_class = UserDatasetForm
     success_url = reverse_lazy('dataset_list')

--- a/open_fmri/apps/dataset/views.py
+++ b/open_fmri/apps/dataset/views.py
@@ -126,7 +126,6 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
         context['investigator_formset_helper'] = InvestigatorFormSetHelper()
         context['link_formset'] = LinkFormSet(instance=self.object)
         context['link_formset_helper'] = LinkFormSetHelper()
-        context['new_contact_form'] = NewContactForm()
         context['publication_document_formset'] = PublicationDocumentFormSet(instance=self.object)
         context['publication_document_formset_helper'] = \
             PublicationDocumentFormSetHelper()
@@ -138,7 +137,8 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
         context['task_formset_helper'] = TaskFormSetHelper()
         context['revision_formset'] = RevisionFormSet(instance=self.object)
         context['revision_formset_helper'] = RevisionFormSetHelper()
-        context['contact_formset'] = ContactFormSet()
+        context['new_contact_form'] = NewContactForm()
+        context['contact_formset'] = ContactFormSet(prefix="contact")
         context['contact_formset_helper'] = ContactFormSetHelper()
         return context
 
@@ -197,6 +197,12 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
             task_formset.save()
         else:
             invalid_form = True
+
+        contact_formset = ContactFormSet(self.request.POST, instance=dataset)
+        if contact_formset.is_valid():
+            contact_formset.save()
+        else:
+            invalid_form = True
         
         if invalid_form:
             context = {
@@ -210,12 +216,14 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
                 'publication_pubmed_link_formset': publication_pubmed_link_formset,
                 'revision_formset': revision_formset,
                 'task_formset': task_formset,
+                'contact_formset': contact_formset,
                 'investigator_formset_helper': InvestigatorFormSetHelper(),
                 'link_formset_helper': LinkFormSetHelper(),
                 'publication_document_formset_helper': PublicationDocumentFormSetHelper(),
                 'publication_pubmed_link_formset_helper': PublicationPubMedLinkFormSetHelper(),
                 'task_formset_helper': TaskFormSetHelper(),
-                'revision_formset_helper': RevisionFormSetHelper()
+                'revision_formset_helper': RevisionFormSetHelper(),
+                'contact_formset_helper': ContactFormSetHelper()
             }
             return self.render_to_response(context)
         else:

--- a/open_fmri/apps/dataset/views.py
+++ b/open_fmri/apps/dataset/views.py
@@ -91,6 +91,7 @@ class DatasetDetail(DetailView):
         context['revisions'] = context_revisions
         context['other_links'] = context_links
         context['ref_papers'] = self.object.referencepaper_set.all()
+        context['has_contacts'] = self.object.contacts.all().count() > 0
         return context
 
 
@@ -143,10 +144,13 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
         if self.object:
             context['contact_formset'] = ContactFormSet(
                 queryset=self.object.contacts.all(),
+                prefix='contacts'
             )
         else:
             context['contact_formset'] = ContactFormSet(
-                queryset=Contact.objects.none()
+                queryset=Contact.objects.none(
+                    prefix='contacts'
+                )
             )
         context['contact_formset_helper'] = ContactFormSetHelper()
         return context
@@ -160,6 +164,7 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
             contact_forms = contact_formset.save()
             for contact_form in contact_forms:
                 dataset.contacts.add(contact_form)
+            dataset.save()
         else:
             invalid_form = True
 

--- a/open_fmri/apps/dataset/views.py
+++ b/open_fmri/apps/dataset/views.py
@@ -142,10 +142,12 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
         context['revision_formset_helper'] = RevisionFormSetHelper()
         if self.object:
             context['contact_formset'] = ContactFormSet(
-                queryset=self.object.contacts.all(),
+                queryset=object.contacts.all(),
             )
         else:
-            context['contact_formset'] = ContactFormSet()
+            context['contact_formset'] = ContactFormSet(
+                queryset=Contact.objects.none()
+            )
         context['contact_formset_helper'] = ContactFormSetHelper()
         return context
 

--- a/open_fmri/apps/dataset/views.py
+++ b/open_fmri/apps/dataset/views.py
@@ -93,7 +93,7 @@ class DatasetDetail(DetailView):
         return context
 
 
-class DatasetCreateUpdate(SingleObjectTemplateResponseMixin,
+class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
                               ModelFormMixin, ProcessFormView):
     model = Dataset
     form_class = DatasetForm

--- a/open_fmri/apps/dataset/views.py
+++ b/open_fmri/apps/dataset/views.py
@@ -140,9 +140,12 @@ class DatasetCreateUpdate(LoginRequiredMixin, SingleObjectTemplateResponseMixin,
         context['task_formset_helper'] = TaskFormSetHelper()
         context['revision_formset'] = RevisionFormSet(instance=self.object)
         context['revision_formset_helper'] = RevisionFormSetHelper()
-        context['contact_formset'] = ContactFormSet(
-            queryset=self.object.contacts.all(),
-        )
+        if self.object:
+            context['contact_formset'] = ContactFormSet(
+                queryset=self.object.contacts.all(),
+            )
+        else:
+            context['contact_formset'] = ContactFormSet()
         context['contact_formset_helper'] = ContactFormSetHelper()
         return context
 

--- a/open_fmri/templates/base.html
+++ b/open_fmri/templates/base.html
@@ -50,6 +50,7 @@
                             <li><a class="dropdown-item" href="/admin/flatpages/flatpage/">Manage Static Pages</a></li>
                             <li><a class="dropdown-item" href="{% url 'user_data_request' %}">Create User Data Request</a></li>
                             <li><a class="dropdown-item" href="{% url 'reference_paper_list' %}">Reference Papers</a></li>
+                            <li><a class="dropdown-item" href="{% url 'contact_list' %}">Contacts</a></li>
                             <li role="separator" class="divider"></li>
                             <li><a class="dropdown-item" href="{% url 'logout' %}">Logout</a>
                         </ul>

--- a/open_fmri/templates/dataset/contact_confirm_delete.html
+++ b/open_fmri/templates/dataset/contact_confirm_delete.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+
+{% block content %}
+    <form action="" method="post">{% csrf_token %}
+        <p> Are you sure you want to delete "{{ object }}"?</p>
+        <input type="submit" value="Confirm" />
+    </form>
+{% endblock %}

--- a/open_fmri/templates/dataset/contact_form.html
+++ b/open_fmri/templates/dataset/contact_form.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% load staticfiles %}
+
+{% block title %}
+{% if object.pk %}
+    Update Contact
+{% else %}
+    Create Contact
+{% endif %}
+{% endblock %}
+
+{% block css %}
+{{ block.super }}
+<link href="{% static 'css/select2.min.css' %}" rel="stylesheet">
+<link rel="stylesheet" href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
+{% endblock %}
+
+{% block content %}
+    {% if object.pk %}
+        <h2>
+            Update Contact
+        </h2>
+    {% else %}
+        <h2>Create Contact</h2>
+    {% endif %}
+
+    <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
+    {% crispy form %}
+    <input class="btn btn-primary" type="submit" value="Save">
+    </form>
+{% endblock %}
+{% block javascript %}
+{{ block.super }}
+{% endblock %}

--- a/open_fmri/templates/dataset/contact_list.html
+++ b/open_fmri/templates/dataset/contact_list.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% load staticfiles %}
+{% block title %}
+    Contacts
+{% endblock %}
+
+{% block css %}
+{{ block.super }}
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.9/css/jquery.dataTables.min.css">
+{% endblock %}
+
+{% block header-image %}
+{% static 'images/banner_view_data.png' %}
+{% endblock %}
+
+{% block content %}
+<h1 class="title">Contacts</h1>
+<h4><a href {% url 'contact_create' %}>Add New Contact</a></h4>
+<table id="dataset-list-table" class="table table-bordered">
+<thead>
+<tr>
+<th> Name </th>
+<th> Email </th>
+<th> Website </th>
+<th></th>
+</tr>
+</thead>
+<tbody>
+{% for contact in object_list %}
+    <tr>
+    <td class="first_td">{{ contact.name }}</td>
+    <td> {{ contact.email }} </td>
+    <td>{{ contact.website }}</td>
+    <td> 
+        <a href="{% url 'contact_update' contact.pk %}">Edit</a><br/>
+        <a href="{% url 'contact_delete' contact.pk %}">Delete</a>
+    </td>
+    </tr>
+{% endfor %} 
+</tbody>
+</table>
+{% endblock %}
+
+{% block javascript %}
+{{ block.super }}
+<script type="text/javascript" language="javascript" src="https://cdn.datatables.net/1.10.9/js/jquery.dataTables.min.js"></script>
+<script type="text/javascript" language="javascript">
+$(document).ready(function() {
+    $('#dataset-list-table').DataTable({
+        "bLengthChange": false,        
+        "pageLength": 50,
+        "order": [[ 1, "asc" ]],
+        });
+});
+</script>
+{% endblock %}

--- a/open_fmri/templates/dataset/dataset_detail.html
+++ b/open_fmri/templates/dataset/dataset_detail.html
@@ -11,7 +11,7 @@
     <h1 class="title">
         {{ object.project_name }}
         {% if user.is_authenticated %}
-            <a href="{% url 'dataset_update' object.accession_number %}">Edit</a><br/> 
+            (<a href="{% url 'dataset_update' object.accession_number %}">Edit</a>)
         {% endif %}
     </h1>
     <p>{{ object.summary|safe }}</p>
@@ -30,17 +30,20 @@
     {% endfor %}
     </ul>
 
-    {% if object.contact %}
+    {% if object.contacts %}
     <h4>Contact Information:</h4>
-        {% if object.contact.name %}
-            Name: {{ object.contact.name }}<br/>
-        {% endif %}
-        {% if object.contact.email %}
-            Email: {{ object.contact.email }}<br/>
-        {% endif %}
-        {% if object.contact.website %}
-            Website: <a href="{{ object.contact.website }}">{{ object.contact.website }}</a><br/>
-        {% endif %}
+        {% for contact in object.contacts.all %}
+            {% if contact.name %}
+                Name: {{ contact.name }}<br/>
+            {% endif %}
+            {% if contact.email %}
+                Email: {{ contact.email }}<br/>
+            {% endif %}
+            {% if contact.website %}
+                Website: <a href="{{ contact.website }}">{{ contact.website }}</a><br/>
+            {% endif %}
+            <br/>
+        {% endfor %}
     {% endif %}
 
     {% if object.acknowledgements %}

--- a/open_fmri/templates/dataset/dataset_detail.html
+++ b/open_fmri/templates/dataset/dataset_detail.html
@@ -32,7 +32,7 @@
 
     {% if has_contacts %}
     <h4>Contact Information:</h4>
-        {% for contact in object.contacts.all %}
+        {% for contact in contacts %}
             {% if contact.name %}
                 Name: {{ contact.name }}<br/>
             {% endif %}

--- a/open_fmri/templates/dataset/dataset_detail.html
+++ b/open_fmri/templates/dataset/dataset_detail.html
@@ -8,7 +8,12 @@
 
 
 {% if user.is_authenticated or object.status == "PUBLISHED" %}
-    <h1 class="title">{{ object.project_name }}</h1>
+    <h1 class="title">
+        {{ object.project_name }}
+        {% if user.is_authenticated %}
+            <a href="{% url 'dataset_update' object.accession_number %}">Edit</a><br/> 
+        {% endif %}
+    </h1>
     <p>{{ object.summary|safe }}</p>
 
     {% if object.task_set.all %}

--- a/open_fmri/templates/dataset/dataset_detail.html
+++ b/open_fmri/templates/dataset/dataset_detail.html
@@ -30,7 +30,7 @@
     {% endfor %}
     </ul>
 
-    {% if object.contacts %}
+    {% if has_contacts %}
     <h4>Contact Information:</h4>
         {% for contact in object.contacts.all %}
             {% if contact.name %}

--- a/open_fmri/templates/dataset/dataset_form.html
+++ b/open_fmri/templates/dataset/dataset_form.html
@@ -18,7 +18,10 @@
 
 {% block content %}
     {% if object.pk %}
-        <h2>Update Dataset</h2>
+        <h2>
+            Update Dataset 
+            (<a href="{% url 'dataset_detail' object.accession_number %}">View</a>)
+        </h2>
     {% else %}
         <h2>Create Dataset</h2>
     {% endif %}
@@ -26,8 +29,8 @@
     <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
     {% crispy form %}
 
-    <label class="control-label"> Contact Information <input type="button" class="btn btn-default" id="contact_toggle" value="hide/show"></label>
-    <div id="id_contactformset">
+    <label class="control-label">Edit/Add Contact Information <input type="button" class="btn btn-default" id="contact_toggle" value="hide/show"></label>
+    <div id="id_contactformset" style="display: None">
         {% crispy contact_formset contact_formset_helper %}
     </div>
 
@@ -86,54 +89,42 @@
             prefix: '{{ link_formset.prefix }}',
             formCssClass: '{{ link_formset.prefix }}'
         });
-    })   
 
-    $(document).ready(function() {
         $('#id_revision .fieldset-control').formset({
             addText: 'Add Revision',
             deleteText: 'Remove',
             prefix: '{{ revision_formset.prefix }}',
             formCssClass: '{{ revision_formset.prefix }}'
         });
-    })
 
-    $(document).ready(function() {
         $('#id_investigator .fieldset-control').formset({
             addText: 'Add Investigator',
             deleteText: 'Remove',
             prefix: '{{ investigator_formset.prefix }}',
             formCssClass: '{{ investigator_formset.prefix }}'
         });
-    })
     
-    $(document).ready(function() {
         $('#id_publication_document .fieldset-control').formset({
             addText: 'Add Publication Document',
             deleteText: 'Remove',
             prefix: 'id_publication_document_set',
             formCssClass: 'id_publication_document_set'
         });
-    })
 
-    $(document).ready(function() {
         $('#id_contactformset .fieldset-control').formset({
             addText: 'Add additional Contact',
             deleteText: 'Remove',
-            prefix: '{{ contact_formset.prefix }}',
-            formCssClass: '{{ contact_formset.prefix }}'
+            prefix: 'id_contacts',
+            formCssClass: 'id_contacts'
         });
-    })
 
-    $(document).ready(function() {
         $('#id_publication_pubmed_link .fieldset-control').formset({
             addText: 'Add Publication PubMed Link',
             deleteText: 'Remove',
             prefix: '{{ publication_pubmed_link_formset.prefix }}',
             formCssClass: '{{ publication_pubmed_link_formset.prefix }}',
         });
-    })
 
-    $(document).ready(function() {
         $('#id_task .fieldset-control').formset({
             addText: 'Add Task',
             deleteText: 'Remove',
@@ -142,13 +133,8 @@
             added: updateCogatSelect,
             formTemplate: task_template
         });
-    })
-
-    
-    $(document).ready(function() {
         $("input[id$='-date_set']").datepicker();
-    });
-    
+    })
 
     var contact_toggle = document.getElementById('contact_toggle');
 

--- a/open_fmri/templates/dataset/dataset_form.html
+++ b/open_fmri/templates/dataset/dataset_form.html
@@ -26,6 +26,7 @@
     <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
     {% crispy form %}
 
+    <label class="control-label"> Contact Information <input type="button" class="btn btn-default" id="contact_toggle" value="hide/show"></label>
     <div id="id_contactformset">
         {% crispy contact_formset contact_formset_helper %}
     </div>
@@ -149,5 +150,16 @@
     });
     
 
+    var contact_toggle = document.getElementById('contact_toggle');
+
+    contact_toggle.onclick = function() {
+        var div = document.getElementById('id_contactformset');
+        if (div.style.display !== 'none') {
+            div.style.display = 'none';
+        }
+        else {
+            div.style.display = 'block';
+        }
+    };
     </script>
 {% endblock %}

--- a/open_fmri/templates/dataset/dataset_form.html
+++ b/open_fmri/templates/dataset/dataset_form.html
@@ -79,6 +79,8 @@
         task_template = $('.task_set:last').clone(true)
         task_template.find('input:hidden[id $= "-DELETE"]').remove();
         $("select[id$='-cogat_id']").select2();
+        $("select[id$='contact']").attr('multiple', true);
+        $("select[id$='contact']").select2();
     });
 
     function updateCogatSelect(row) {
@@ -122,11 +124,11 @@
     })
 
     $(document).ready(function() {
-        $('#id_contact_formset .fieldset-control').formset({
+        $('#id_contactformset .fieldset-control').formset({
             addText: 'Add additional Contact',
             deleteText: 'Remove',
-            prefix: 'id_contact_formset_set',
-            formCssClass: 'id_contact_formset_set'
+            prefix: '{{ contact_formset.prefix }}',
+            formCssClass: '{{ contact_formset.prefix }}'
         });
     })
 

--- a/open_fmri/templates/dataset/dataset_form.html
+++ b/open_fmri/templates/dataset/dataset_form.html
@@ -54,8 +54,12 @@
         {% crispy contact_form %}
     </div>
     
-     <div id="id_new_contact">
+    <div id="id_new_contact">
         {% crispy new_contact_form %}
+    </div>
+
+    <div id="id_contactformset">
+        {% crispy contact_formset contact_formset_helper %}
     </div>
 
     <input class="btn btn-primary" type="submit" value="Save">
@@ -114,6 +118,15 @@
             deleteText: 'Remove',
             prefix: 'id_publication_document_set',
             formCssClass: 'id_publication_document_set'
+        });
+    })
+
+    $(document).ready(function() {
+        $('#id_contact_formset .fieldset-control').formset({
+            addText: 'Add additional Contact',
+            deleteText: 'Remove',
+            prefix: 'id_contact_formset_set',
+            formCssClass: 'id_contact_formset_set'
         });
     })
 

--- a/open_fmri/templates/dataset/dataset_form.html
+++ b/open_fmri/templates/dataset/dataset_form.html
@@ -29,11 +29,6 @@
     <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
     {% crispy form %}
 
-    <label class="control-label">Edit/Add Contact Information <input type="button" class="btn btn-default" id="contact_toggle" value="hide/show"></label>
-    <div id="id_contactformset" style="display: None">
-        {% crispy contact_formset contact_formset_helper %}
-    </div>
-
     <div id="id_task">
         {% crispy task_formset task_formset_helper %}
     </div>
@@ -82,6 +77,7 @@
         select_elem = row.find("select[id$='-cogat_id']");
         select_elem.select2();
     }
+
      $(document).ready(function() {
         $('#id_link .fieldset-control').formset({
             addText: 'Add Link',
@@ -111,13 +107,6 @@
             formCssClass: 'id_publication_document_set'
         });
 
-        $('#id_contactformset .fieldset-control').formset({
-            addText: 'Add additional Contact',
-            deleteText: 'Remove',
-            prefix: 'id_contacts',
-            formCssClass: 'id_contacts'
-        });
-
         $('#id_publication_pubmed_link .fieldset-control').formset({
             addText: 'Add Publication PubMed Link',
             deleteText: 'Remove',
@@ -135,17 +124,5 @@
         });
         $("input[id$='-date_set']").datepicker();
     })
-
-    var contact_toggle = document.getElementById('contact_toggle');
-
-    contact_toggle.onclick = function() {
-        var div = document.getElementById('id_contactformset');
-        if (div.style.display !== 'none') {
-            div.style.display = 'none';
-        }
-        else {
-            div.style.display = 'block';
-        }
-    };
     </script>
 {% endblock %}

--- a/open_fmri/templates/dataset/dataset_form.html
+++ b/open_fmri/templates/dataset/dataset_form.html
@@ -26,6 +26,10 @@
     <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
     {% crispy form %}
 
+    <div id="id_contactformset">
+        {% crispy contact_formset contact_formset_helper %}
+    </div>
+
     <div id="id_task">
         {% crispy task_formset task_formset_helper %}
     </div>
@@ -50,18 +54,6 @@
         {% crispy revision_formset revision_formset_helper %}
     </div>
 
-    <div id="id_contact">
-        {% crispy contact_form %}
-    </div>
-    
-    <div id="id_new_contact">
-        {% crispy new_contact_form %}
-    </div>
-
-    <div id="id_contactformset">
-        {% crispy contact_formset contact_formset_helper %}
-    </div>
-
     <input class="btn btn-primary" type="submit" value="Save">
 
     </form>
@@ -79,8 +71,7 @@
         task_template = $('.task_set:last').clone(true)
         task_template.find('input:hidden[id $= "-DELETE"]').remove();
         $("select[id$='-cogat_id']").select2();
-        $("select[id$='contact']").attr('multiple', true);
-        $("select[id$='contact']").select2();
+        $("select[id$='contacts']").select2();
     });
 
     function updateCogatSelect(row) {

--- a/open_fmri/templates/dataset/dataset_form.html
+++ b/open_fmri/templates/dataset/dataset_form.html
@@ -29,6 +29,11 @@
     <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
     {% crispy form %}
 
+    <label class="control-label">Edit Contact Information<input type="button" class="btn btn-default" id="contact_toggle" value="hide/show"></label>
+    <div id="id_contact" style="display: None;">
+        {% crispy contact_formset contact_formset_helper %}
+    </div>
+
     <div id="id_task">
         {% crispy task_formset task_formset_helper %}
     </div>
@@ -122,7 +127,27 @@
             added: updateCogatSelect,
             formTemplate: task_template
         });
+
+       $('#id_contact .fieldset-control').formset({
+            addText: 'Add Contact',
+            deleteText: 'Remove',
+            prefix: '{{ contact_formset.prefix }}',
+            formCssClass: '{{ contact_formset.prefix }}'
+        });
+
+
         $("input[id$='-date_set']").datepicker();
     })
+
+    var contact_toggle = document.getElementById('contact_toggle');
+    contact_toggle.onclick = function() {
+        var div = document.getElementById('id_contact');
+        if (div.style.display !== 'none') {
+            div.style.display = 'none';
+        }
+        else {
+            div.style.display = 'block';
+        }
+    };
     </script>
 {% endblock %}


### PR DESCRIPTION
A single test is breaking on circle right now but the test works fine locally so I'm proceeding with this PR.

Added support for multiple contacts per dataset. Datasets can share contacts. For now contacts are ordered alphabetically. Can edit and add new contacts in the dataset edit view. Also added dedicated contact CRUD views and templates accessible in the top right drop down menu.

Added links from dataset edit view to the detail view, and vice versa for logged in users.

Saving the dataset now redirects to the dataset detail view instead of the dataset list.
